### PR TITLE
Optimise status command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - develop
   pull_request:
 env:
-  version_in_development: v0.0.13
+  version_in_development: v0.0.14
 
 jobs:
   draft-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Create Release
         id: draft_release
-        if: github.ref == 'refs/heads/develop' || github.head_ref == 'feature/status'
+        if: github.ref == 'refs/heads/develop' || github.head_ref == 'feature/sha1-streaming'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - develop
   pull_request:
 env:
-  version_in_development: v0.0.14
+  version_in_development: v0.0.15
 
 jobs:
   draft-release:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - develop
   pull_request:
 env:
-  version_in_development: v0.0.15
+  version_in_development: v0.0.16
 
 jobs:
   draft-release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "same-file",
  "serde",
  "serde_json",
+ "threadpool",
  "ureq",
  "url",
  "walkdir",
@@ -943,6 +944,15 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.8.0"
 fs2 = "0.4.3"
 filetime = "0.2.19"
 same-file = "1.0.6"
+threadpool = "1.8.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.10"

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -107,9 +107,7 @@ fn probe_snapshot_files(
             #[cfg(not(target_family = "windows"))]
             let path = original_path.clone();
 
-            if path != "."
-                && path.starts_with("./elfshaker_data") == false
-            {
+            if path != "." && !path.starts_with("./elfshaker_data") {
                 normalised_paths.insert(path);
 
                 if metadata.is_symlink() {

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -226,8 +226,8 @@ fn probe_snapshot_files(
         };
 
         let mut path_string = path.display().to_string();
-        if !path_string.starts_with("./") {
-            path_string = "./".to_string() + &path_string;
+        if path_string.starts_with("./") == false {
+            path_string = format!("./{}", path_string);
         }
 
         if changed {

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -104,14 +104,12 @@ fn probe_snapshot_files(
             #[cfg(target_family = "windows")]
             let path = Repository::replace_back_to_slash(&original_path);
             #[cfg(not(target_family = "windows"))]
-            let path = original_path.clone();
+            let mut path = original_path.clone();
 
             if path != "."
                 && path.starts_with("./elfshaker_data") == false
                 && path.starts_with("./.git") == false
             {
-                normalised_paths.insert(path);
-
                 if metadata.is_symlink() {
                     if let Ok(target) = fs::read_link(original_path) {
                         let target = if target.is_absolute() {
@@ -224,11 +222,15 @@ fn probe_snapshot_files(
                 }
             }
         };
+        let mut path_string = path.display().to_string();
+        if !path_string.starts_with("./") {
+            path_string += &("./".to_string() + &path_string);
+        }
 
         if changed {
-            changed_files.insert(path.display().to_string());
+            changed_files.insert(path_string);
         } else {
-            unchanged_files.insert(path.display().to_string());
+            unchanged_files.insert(path_string);
         }
     }
 

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -109,10 +109,10 @@ fn probe_snapshot_files(
                 && path.starts_with("./elfshaker_data") == false
                 && path.starts_with("./.git") == false
             {
-                if path.starts_with("./"){
-                   let path_without_dot =  path.split_off(2);
-                   normalised_paths.insert(path_without_dot);
-                }else{
+                if path.starts_with("./") {
+                    let path_without_dot = path.split_off(2);
+                    normalised_paths.insert(path_without_dot);
+                } else {
                     normalised_paths.insert(path);
                 }
 

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -109,10 +109,10 @@ fn probe_snapshot_files(
                 && path.starts_with("./elfshaker_data") == false
                 && path.starts_with("./.git") == false
             {
-                if path.starts_with("./") {
-                    let path_without_dot = path.split_off(2);
-                    normalised_paths.insert(path_without_dot);
-                } else {
+                if path.starts_with("./"){
+                   let path_without_dot =  path.split_off(2);
+                   normalised_paths.insert(path_without_dot);
+                }else{
                     normalised_paths.insert(path);
                 }
 

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -104,12 +104,14 @@ fn probe_snapshot_files(
             #[cfg(target_family = "windows")]
             let path = Repository::replace_back_to_slash(&original_path);
             #[cfg(not(target_family = "windows"))]
-            let mut path = original_path.clone();
+            let path = original_path.clone();
 
             if path != "."
                 && path.starts_with("./elfshaker_data") == false
                 && path.starts_with("./.git") == false
             {
+                normalised_paths.insert(path);
+
                 if metadata.is_symlink() {
                     if let Ok(target) = fs::read_link(original_path) {
                         let target = if target.is_absolute() {
@@ -222,15 +224,11 @@ fn probe_snapshot_files(
                 }
             }
         };
-        let mut path_string = path.display().to_string();
-        if !path_string.starts_with("./") {
-            path_string += &("./".to_string() + &path_string);
-        }
 
         if changed {
-            changed_files.insert(path_string);
+            changed_files.insert(path.display().to_string());
         } else {
-            unchanged_files.insert(path_string);
+            unchanged_files.insert(path.display().to_string());
         }
     }
 

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -109,7 +109,6 @@ fn probe_snapshot_files(
 
             if path != "."
                 && path.starts_with("./elfshaker_data") == false
-                && path.starts_with("./.git") == false
             {
                 normalised_paths.insert(path);
 
@@ -164,15 +163,15 @@ fn probe_snapshot_files(
             info!("not in workspace {}", path.display());
             true
         } else {
-            let workspace_is_symlink = path.is_symlink();
+            let file_in_workspace_is_symlink = path.is_symlink();
 
-            if entry.file_metadata.is_symlink_file != workspace_is_symlink {
+            if entry.file_metadata.is_symlink_file != file_in_workspace_is_symlink {
                 info!(
                     "symlink status differs from recording for {}",
                     path.display()
                 );
                 true
-            } else if workspace_is_symlink {
+            } else if file_in_workspace_is_symlink {
                 let workspace_target = fs::read_link(path)?;
                 let changed = entry.file_metadata.symlink_target != workspace_target;
                 if changed {

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -115,17 +115,13 @@ fn probe_snapshot_files(
                 } else {
                     normalised_paths.insert(path);
                 }
-
             }
         }
 
         workspace_files_sender
             .send(normalised_paths)
             .expect("unable to send file list to main thread");
-
-
     });
-
 
     let mut changed_files = HashSet::new(); // vec![];
     let mut unchanged_files = HashSet::new(); // vec![];
@@ -215,7 +211,6 @@ fn probe_snapshot_files(
     let workspace_file_paths = workspace_files_receiver
         .recv()
         .expect("unable to fetch sorted file list from worker thread");
-        
 
     Ok(add_untracked_files(
         changed_files,

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -86,9 +86,10 @@ fn probe_snapshot_files(
 ) -> Result<Vec<String>, Box<dyn StdError>> {
     let pool = threadpool::ThreadPool::new(1);
     let (workspace_files_sender, workspace_files_receiver) = channel();
-
     pool.execute(move || {
+        let base_dir = std::env::current_dir().expect("unable to get current working directory");
         let mut normalised_paths = HashSet::new();
+        let mut symlink_targets_in_tree = HashSet::new();
 
         let walker = walkdir::WalkDir::new(".");
         for entry in walker {
@@ -101,31 +102,50 @@ fn probe_snapshot_files(
             let original_path = entry.path().display().to_string();
 
             #[cfg(target_family = "windows")]
-            let mut path = Repository::replace_back_to_slash(&original_path);
+            let path = Repository::replace_back_to_slash(&original_path);
             #[cfg(not(target_family = "windows"))]
-            let mut path = original_path.clone();
+            let path = original_path.clone();
 
             if path != "."
                 && path.starts_with("./elfshaker_data") == false
                 && path.starts_with("./.git") == false
             {
-                if path.starts_with("./"){
-                   let path_without_dot =  path.split_off(2);
-                   normalised_paths.insert(path_without_dot);
-                }else{
-                    normalised_paths.insert(path);
-                }
+                normalised_paths.insert(path);
 
+                if metadata.is_symlink() {
+                    if let Ok(target) = fs::read_link(original_path) {
+                        let target = if target.is_absolute() {
+                            // make relative
+                            if let Ok(target) = target.strip_prefix(&base_dir) {
+                                target
+                            } else {
+                                // out of tree, skipping
+                                continue;
+                            }
+                        } else {
+                            &target
+                        };
+
+                        let path = target.display().to_string();
+                        #[cfg(target_family = "windows")]
+                        let path = Repository::replace_back_to_slash(&*path);
+
+                        //println!("symlink target: {path}");
+                        symlink_targets_in_tree.insert(path);
+                    }
+                }
             }
         }
 
+        let filtered_paths = normalised_paths
+            .difference(&symlink_targets_in_tree)
+            .cloned()
+            .collect();
+
         workspace_files_sender
-            .send(normalised_paths)
+            .send(filtered_paths)
             .expect("unable to send file list to main thread");
-
-
     });
-
 
     let mut changed_files = HashSet::new(); // vec![];
     let mut unchanged_files = HashSet::new(); // vec![];
@@ -215,7 +235,6 @@ fn probe_snapshot_files(
     let workspace_file_paths = workspace_files_receiver
         .recv()
         .expect("unable to fetch sorted file list from worker thread");
-        
 
     Ok(add_untracked_files(
         changed_files,

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -115,13 +115,17 @@ fn probe_snapshot_files(
                 } else {
                     normalised_paths.insert(path);
                 }
+
             }
         }
 
         workspace_files_sender
             .send(normalised_paths)
             .expect("unable to send file list to main thread");
+
+
     });
+
 
     let mut changed_files = HashSet::new(); // vec![];
     let mut unchanged_files = HashSet::new(); // vec![];
@@ -211,6 +215,7 @@ fn probe_snapshot_files(
     let workspace_file_paths = workspace_files_receiver
         .recv()
         .expect("unable to fetch sorted file list from worker thread");
+        
 
     Ok(add_untracked_files(
         changed_files,

--- a/src/bin/elfshaker/status.rs
+++ b/src/bin/elfshaker/status.rs
@@ -225,10 +225,15 @@ fn probe_snapshot_files(
             }
         };
 
+        let mut path_string = path.display().to_string();
+        if !path_string.starts_with("./") {
+            path_string = "./".to_string() + &path_string;
+        }
+
         if changed {
-            changed_files.insert(path.display().to_string());
+            changed_files.insert(path_string);
         } else {
-            unchanged_files.insert(path.display().to_string());
+            unchanged_files.insert(path_string);
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -129,7 +129,7 @@ fn package_file_see_status_symlink() -> Result<(), Box<dyn std::error::Error>> {
     let foo_file = temp.child("foo.txt");
     foo_file.touch().unwrap();
     foo_file
-        .write_str("Snapshot 1 contents")
+        .write_str("FOO FOO CONTENT")
         .expect("unable to write initially");
 
     let mut symlink_file = temp.to_path_buf();
@@ -165,13 +165,13 @@ fn package_file_see_status_symlink() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir(temp.path());
     let clean = cmd.output()?;
     assert!(clean.status.success());
-    assert_eq!(b"[]\n".as_ref(), clean.stdout);
+    assert_eq!("[]", String::from_utf8_lossy(&clean.stdout).trim());
     //.assert().success();
 
     // 5. modify file
     println!("modify foo.txt");
     foo_file
-        .write_str("Snapshot 1 contents appended")
+        .write_str("FOO File Replaced")
         .expect("unable to update foo.txt");
 
     // 6. check status: ["foo.txt"]
@@ -187,7 +187,9 @@ fn package_file_see_status_symlink() -> Result<(), Box<dyn std::error::Error>> {
 
     // 7. modify symlink
     let bar_file = temp.child("bar.txt");
-    bar_file.touch().unwrap();
+    bar_file
+        .write_str("bar bar")
+        .expect("unable to write bar.txt");
     remove_file(&symlink_file).expect("unable to remove symlink_file");
     symlink(&bar_file, symlink_file).expect("unable to update symlink");
 
@@ -198,7 +200,7 @@ fn package_file_see_status_symlink() -> Result<(), Box<dyn std::error::Error>> {
     let dirty = cmd.output()?;
     assert!(dirty.status.success());
     assert_eq!(
-        r#"["./foo.txt","./link.txt"]"#.to_string(),
+        r#"["./bar.txt","./foo.txt","./link.txt"]"#.to_string(),
         String::from_utf8_lossy(&dirty.stdout).trim()
     );
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -272,7 +272,15 @@ fn symlink_to_directory() -> Result<(), Box<dyn std::error::Error>> {
 
     // 5. modify symlink
     println!("removing symlink_dir");
-    remove_dir(&symlink_dir).expect("unable to remove symlink_dir");
+    cfg_if::cfg_if! {
+        if #[cfg(target_family = "unix")] {
+            remove_file(&symlink_dir).expect("unable to remove symlink_dir");
+        } else if #[cfg(target_family = "windows")] {
+            remove_dir(&symlink_dir).expect("unable to remove symlink_dir");
+        } else {
+            compile_error!("symlink not implemented for target_family");
+        }
+    }
     println!("creating updated symlink_dir");
     symlink(&real_dir_2, symlink_dir).expect("unable to update symlink");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,10 +1,7 @@
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
-use std::{
-    fs::{remove_dir, remove_file},
-    process::Command,
-};
+use std::{fs::remove_file, process::Command};
 
 // main use case: loosen and repackage in order to add a snapshot to an existing pack. Should be
 // faster than unpacking each single snapshot.
@@ -276,7 +273,7 @@ fn symlink_to_directory() -> Result<(), Box<dyn std::error::Error>> {
         if #[cfg(target_family = "unix")] {
             remove_file(&symlink_dir).expect("unable to remove symlink_dir");
         } else if #[cfg(target_family = "windows")] {
-            remove_dir(&symlink_dir).expect("unable to remove symlink_dir");
+            std::fs::remove_dir(&symlink_dir).expect("unable to remove symlink_dir");
         } else {
             compile_error!("symlink not implemented for target_family");
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -98,7 +98,7 @@ fn package_file_see_status() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir(temp.path());
     let clean = cmd.output()?;
     assert!(clean.status.success());
-    assert_eq!(b"[]\n".as_ref(), clean.stdout);
+    assert_eq!("[]\n".to_string(), String::from_utf8_lossy(&clean.stdout));
     //.assert().success();
 
     // 5. modify file


### PR DESCRIPTION
New features:

- [x] Include results that are in the workspace but not the snapshot
- [x] Use modified time as a heuristic to reduce the amount of hashing performed
- [x] Calculate the sha1sum with a 4KB sliding buffer in status subcommand
- [x] Windows Symlink handle folders as well

Optional goals:

- [ ] Move some code in the library portion

The average time to set a status on a build install tree of boost version 1.80 (15 000 file) is (calculate an average of 10 runs without modification and 10 runs with modification) :

- elfshaker release -> 7.057s
- elfshaker of this pr -> 1.101s

The size of the directory is 360.8 MB :

- the largest file 988KB
- the smallest file 1KB

The average time to set a status on a build tree of llvm (2822) is (calculate an average of 10 runs without modification and 10 runs with modification) :

- elfshaker release -> 40.214 s
- elfshaker of this pr -> 0.169 s

The size of the directory is 19,6GB :

- the largest file 298MB
- the smallest file 4KB

