### PR TITLE
Extending the valid alphabet of snapshots and packs 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,13 +140,6 @@ fn extract(
     opts: bridge::ExtractOptions,
 ) -> Result<ExtractResult, Box<dyn Error>> {
     let _ = LAZY_LOGGER.clone();
-    println!(
-        "Options extracted {} {} {} {}",
-        opts.verify(),
-        opts.force(),
-        opts.reset,
-        opts.num_workers
-    );
     let result = extract::do_extract(
         std::path::PathBuf::from(elfshaker_repo_dir.to_string()),
         std::path::PathBuf::from(worktree_dir.to_string()),

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -712,7 +712,6 @@ impl Repository {
         let mut frames = vec![];
         let mut frame_bufs = vec![];
 
-        println!("There are opts.num_workers {}", opts.num_workers);
         let frame_results = run_in_parallel(
             opts.num_workers as usize,
             object_partitions.into_iter(),

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -323,11 +323,11 @@ impl Repository {
     }
 
     pub fn is_pack(&self, pack_id: &str) -> Result<Option<PackId>, IdError> {
+        let pack_index_file_name = format!("{pack_id}.{}", PACK_INDEX_EXTENSION);
         let pack_index_path = self
             .data_dir
             .join(PACKS_DIR)
-            .join(pack_id)
-            .with_extension(PACK_INDEX_EXTENSION);
+            .join(pack_index_file_name);
         pack_index_path
             .exists()
             .then(|| PackId::from_str(pack_id))
@@ -345,21 +345,23 @@ impl Repository {
             return false;
         }
 
+        let pack_index_file_name = format!("{pack_name}.{}", PACK_INDEX_EXTENSION);
         let pack_index_path = self
             .data_dir
             .join(PACKS_DIR)
-            .join(pack_name)
-            .with_extension(PACK_INDEX_EXTENSION);
+            .join(pack_index_file_name);
         pack_index_path.exists()
     }
 
     pub fn load_index(&self, pack_id: &PackId) -> Result<PackIndex, Error> {
         let pack_index_path = match pack_id {
-            PackId::Pack(name) => self
-                .data_dir
-                .join(PACKS_DIR)
-                .join(name)
-                .with_extension(PACK_INDEX_EXTENSION),
+            PackId::Pack(name) =>{
+                let file_name = format!("{name}.{}", PACK_INDEX_EXTENSION);
+                self
+                    .data_dir
+                    .join(PACKS_DIR)
+                    .join(file_name)
+            }
         };
         info!("Load index {} {}", pack_id, pack_index_path.display());
         Ok(PackIndex::load(pack_index_path)?)
@@ -367,11 +369,13 @@ impl Repository {
 
     pub fn load_index_snapshots(&self, pack_id: &PackId) -> Result<Vec<String>, Error> {
         let pack_index_path = match pack_id {
-            PackId::Pack(name) => self
-                .data_dir
-                .join(PACKS_DIR)
-                .join(name)
-                .with_extension(PACK_INDEX_EXTENSION),
+            PackId::Pack(name) => {
+                let file_name = format!("{name}.{}", PACK_INDEX_EXTENSION);
+                self
+                    .data_dir
+                    .join(PACKS_DIR)
+                    .join(file_name)
+            }
         };
         Ok(PackIndex::load_only_snapshots(pack_index_path)?)
     }
@@ -630,11 +634,10 @@ impl Repository {
         let loose_path = self.data_dir().join(PACKS_DIR).join(LOOSE_DIR);
         ensure_dir(&loose_path)?;
 
-        index.save(
-            &loose_path
-                .join(snapshot.tag())
-                .with_extension(PACK_INDEX_EXTENSION),
-        )?;
+        let index_path =  &loose_path
+            .join(format!("{}.{}", snapshot.tag(), PACK_INDEX_EXTENSION));
+
+        index.save(index_path)?;
 
         self.update_head(snapshot)?;
 

--- a/tests/test_cxxbridge.cpp
+++ b/tests/test_cxxbridge.cpp
@@ -1,6 +1,6 @@
 #define BOOST_TEST_MODULE test_cxxbridge
 #include <boost/test/included/unit_test.hpp>
-
+#include <boost/test/data/test_case.hpp>
 #include <boost/filesystem.hpp>
 
 #include <elfshaker-cxxbridge/lib.h>
@@ -11,7 +11,16 @@
 
 namespace fs = boost::filesystem;
 
-BOOST_AUTO_TEST_CASE(store_with_separate_worktree_smoke_test) {
+
+const auto TEST_DATA_SNAPSHOT_NAMES = boost::unit_test::data::make({ "myrevision.hash" , "myrevision-hash", "my revision", "myrevision_hash", "myrevision🔥hash" });
+const auto TEST_DATA_PACK_NAMES = boost::unit_test::data::make({ "my-pack", "my pack", "my_pack", "my.pack", "my🔥pack" });
+
+
+BOOST_DATA_TEST_CASE(store_with_separate_worktree_smoke_test, 
+  TEST_DATA_SNAPSHOT_NAMES * TEST_DATA_PACK_NAMES, 
+  td_snapshot_name,
+  td_pack_name
+) {
   auto temp_test_path = fs::temp_directory_path() / "elfshkr-test" / fs::unique_path();
   std::string worktree_path = temp_test_path.generic_string();
   worktree_path += "/worktree";
@@ -27,7 +36,7 @@ BOOST_AUTO_TEST_CASE(store_with_separate_worktree_smoke_test) {
 
   pre::file::from_string((fs::path{worktree_path} / "README.md").generic_string(), "A readme to store!");
 
-  elfshaker::store( elfshaker_data_dir, worktree_path, { "README.md" }, "myrevision-hash"); 
+  elfshaker::store( elfshaker_data_dir, worktree_path, { "README.md" }, td_snapshot_name); 
 
   elfshaker::ExtractOptions extract_options{};
   extract_options.verify = false;
@@ -44,7 +53,7 @@ BOOST_AUTO_TEST_CASE(store_with_separate_worktree_smoke_test) {
     << std::endl;
   }
   {
-    auto extracted = elfshaker::extract( elfshaker_data_dir, worktree_path, "myrevision-hash", extract_options);
+    auto extracted = elfshaker::extract( elfshaker_data_dir, worktree_path, td_snapshot_name, extract_options);
 
     std::cout << "A: " <<  extracted.added_file_count << "\n";
     std::cout << "D: " <<  extracted.removed_file_count << "\n";
@@ -67,11 +76,11 @@ BOOST_AUTO_TEST_CASE(store_with_separate_worktree_smoke_test) {
     << std::endl;
   }
   {
-    elfshaker::pack(elfshaker_data_dir, worktree_path, "mypack", 12, 0);
+    elfshaker::pack(elfshaker_data_dir, worktree_path, td_pack_name, 12, 0);
   }
 
   {
-    auto extracted = elfshaker::extract( elfshaker_data_dir, worktree_path, "myrevision-hash", extract_options);
+    auto extracted = elfshaker::extract( elfshaker_data_dir, worktree_path, td_snapshot_name, extract_options);
 
     std::cout << "A: " <<  extracted.added_file_count << "\n";
     std::cout << "D: " <<  extracted.removed_file_count << "\n";
@@ -81,7 +90,7 @@ BOOST_AUTO_TEST_CASE(store_with_separate_worktree_smoke_test) {
 
 
   {
-    auto status_list = elfshaker::status(elfshaker_data_dir, worktree_path, "myrevision-hash");
+    auto status_list = elfshaker::status(elfshaker_data_dir, worktree_path, td_snapshot_name);
     std::cout << "Status List : " << std::endl;
     for (auto st : status_list) {
       std::cout << st << std::endl;


### PR DESCRIPTION
With this PR pack and snapshot names can be valid filenames of `valid_filename(Windows) ∩ valid_filename(Linux) ∩ valid_paths(MacOs)`

This means all characters except `'<', '>', ':', '"', '|', '?', '*'` + all ASCII control chars (which includes `\0`)

Extended the C++ test to ensure this works as expected