### PR TITLE
Fix pack extraction when using truly separate worktree

### DIFF
--- a/.github/workflows/ci-cmake.yaml
+++ b/.github/workflows/ci-cmake.yaml
@@ -70,7 +70,7 @@ jobs:
           asset_content_type: application/zip
       - name: run tests 
         run: |
-          C:\Users\runneradmin\AppData\Local\tipi\tipi.exe . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists --test all -- -DBUILD_TESTING=ON
+          C:\Users\runneradmin\AppData\Local\tipi\tipi.exe . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists --test all --test-jobs 1 -- -DBUILD_TESTING=ON
 
   build-macos:
     name: build-macos

--- a/src/repo/pack.rs
+++ b/src/repo/pack.rs
@@ -311,13 +311,12 @@ impl Pack {
     /// # Arguments
     ///
     /// * `pack_name` - The base filename ([`Path::file_stem`]) of the pack.
-    pub fn open<P>(repo: P, pack_name: &PackId) -> Result<Self, Error>
+    pub fn open<P>(repo_data_dir: P, pack_name: &PackId) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
         let PackId::Pack(pack_name) = pack_name;
-        let mut packs_data = repo.as_ref().join(&REPO_DIR);
-        packs_data.push(PACKS_DIR);
+        let mut packs_data = repo_data_dir.as_ref().join(&PACKS_DIR);
 
         let pack_index_path = packs_data.join(format!("{}.{}", pack_name, PACK_INDEX_EXTENSION));
         let pack_path = packs_data.join(format!("{}.{}", pack_name, PACK_EXTENSION));

--- a/src/repo/repository.rs
+++ b/src/repo/repository.rs
@@ -230,7 +230,7 @@ impl Repository {
 
     /// Open the pack.
     pub fn open_pack(&self, pack: &PackId) -> Result<Pack, Error> {
-        Pack::open(&self.path, pack)
+        Pack::open(&self.data_dir, pack)
     }
 
     pub fn packs(&self) -> Result<Vec<PackId>, Error> {


### PR DESCRIPTION
This search Packs within repo data_dir instead of always in the repo_worktree / "elfshaker_data"

This hardens the tests to actually extract a pack and not the snapshot of the same name to verify pack extraction is working as expected.