### PR TITLE
:rocket: Tagging elfshaker v0.0.19 as used as a library by cmake-re …0.0.71 + v0.0.72

### DIFF
--- a/.github/workflows/ci-cmake.yaml
+++ b/.github/workflows/ci-cmake.yaml
@@ -54,7 +54,7 @@ jobs:
           ./install_for_windows.ps1
           Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "rustup-init.exe"
           ./rustup-init.exe -q -y
-          New-Item ".tipi/opts" -ItemType File -Value "set(BUILD_TESTING ON CACHE BOOL \"\" FORCE)"
+          New-Item ".tipi/opts" -ItemType File -Value 'set(BUILD_TESTING ON CACHE BOOL "" FORCE)'
           tipi connect
           tipi . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists
           mv .\build\vs-16-2019-win64-cxx17\bin\elfshaker_executable.exe .\build\vs-16-2019-win64-cxx17\bin\elfshaker.exe

--- a/.github/workflows/ci-cmake.yaml
+++ b/.github/workflows/ci-cmake.yaml
@@ -3,7 +3,7 @@ name: cmake-build
 on:
   pull_request:
 env:
-  version_in_development: v0.0.17
+  version_in_development: v0.0.19
   TIPI_CACHE_FORCE_ENABLE: ON
   CMAKE_TIPI_PROVIDER_ENABLE: ON
   TIPI_ACCESS_TOKEN: ${{ secrets.ELFSHAKER_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}

--- a/.github/workflows/ci-cmake.yaml
+++ b/.github/workflows/ci-cmake.yaml
@@ -54,8 +54,9 @@ jobs:
           ./install_for_windows.ps1
           Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "rustup-init.exe"
           ./rustup-init.exe -q -y
+          New-Item ".tipi/opts" -ItemType File -Value "set(BUILD_TESTING ON CACHE BOOL \"\" FORCE)"
           tipi connect
-          tipi . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists -- -DBUILD_TESTING=ON
+          tipi . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists
           mv .\build\vs-16-2019-win64-cxx17\bin\elfshaker_executable.exe .\build\vs-16-2019-win64-cxx17\bin\elfshaker.exe
           Compress-Archive -Path .\build\vs-16-2019-win64-cxx17\bin\elfshaker.exe -DestinationPath ./elfshaker-win.zip
       - name: Upload elfshaker package
@@ -70,7 +71,7 @@ jobs:
           asset_content_type: application/zip
       - name: run tests 
         run: |
-          C:\Users\runneradmin\AppData\Local\tipi\tipi.exe . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists --test all --test-jobs 1 -- -DBUILD_TESTING=ON
+          C:\Users\runneradmin\AppData\Local\tipi\tipi.exe . -t vs-16-2019-win64-cxx17 -C Release --dont-upgrade --verbose --use-cmakelists --test all --test-jobs 1
 
   build-macos:
     name: build-macos
@@ -93,10 +94,10 @@ jobs:
           ./install_for_macos_linux.sh
           curl -fSL https://sh.rustup.rs --output ./sh.rustup.sh
           chmod +x ./sh.rustup.sh
-
+          echo "set(BUILD_TESTING ON CACHE BOOL \"\" FORCE)" >> .tipi/opts
           tipi run ./sh.rustup.sh -q -y --default-host x86_64-apple-darwin --default-toolchain stable-x86_64-apple-darwin
           tipi connect
-          tipi . -t macos-cxx17 --dont-upgrade --verbose --use-cmakelists -- -DBUILD_TESTING=ON
+          tipi . -t macos-cxx17 --dont-upgrade --verbose --use-cmakelists
           chmod +x ./build/macos-cxx17/bin/elfshaker_executable
           mv ./build/macos-cxx17/bin/elfshaker_executable ./build/macos-cxx17/bin/elfshaker
           zip -j elfshaker-macos.zip ./build/macos-cxx17/bin/elfshaker
@@ -112,7 +113,7 @@ jobs:
           asset_content_type: application/zip
       - name: run tests 
         run: |
-          tipi . -t macos-cxx17 --dont-upgrade --verbose --use-cmakelists --test all -- -DBUILD_TESTING=ON
+          tipi . -t macos-cxx17 --dont-upgrade --verbose --use-cmakelists --test all
 
   build-linux:
     name: build-linux
@@ -130,6 +131,7 @@ jobs:
       - name: install and build 
         run: |
           export HOME="/home/tipi"
+          echo "set(BUILD_TESTING ON CACHE BOOL \"\" FORCE)" >> .tipi/opts
           tipi connect
 
           sudo apt update && sudo apt install zip -y
@@ -138,7 +140,7 @@ jobs:
           ./sh.rustup.sh -q -y --no-modify-path
           export PATH="$HOME/.cargo/bin:$PATH"
 
-          tipi . -t linux-cxx17 --dont-upgrade --verbose --use-cmakelists -- -DBUILD_TESTING=ON
+          tipi . -t linux-cxx17 --dont-upgrade --verbose --use-cmakelists
           chmod +x ./build/linux-cxx17/bin/elfshaker_executable
           mv ./build/linux-cxx17/bin/elfshaker_executable ./build/linux-cxx17/bin/elfshaker
           zip -j elfshaker-linux.zip ./build/linux-cxx17/bin/elfshaker
@@ -155,4 +157,4 @@ jobs:
       - name: run tests
         run: |
           export HOME="/home/tipi"
-          tipi . -t linux-cxx17 --dont-upgrade --verbose --use-cmakelists --test all -- -DBUILD_TESTING=ON
+          tipi . -t linux-cxx17 --dont-upgrade --verbose --use-cmakelists --test all


### PR DESCRIPTION
# CHANGELOG

## Features
- :new: Supports separate worktree for elfshaker repository, like git separate worktree it allows to have elfshaker_data/ outside of the folder cached.
- Library API + C++ static library API with cxxbridge and cxx.rs
  - Builds with CMake, which wraps rust via [tipi-build/corrosion extended fork](https://github.com/tipi-build/corrosion/)
  - Detailed logging activable via `VERBOSE=1` environment variable
- Extended the valid alphabet of snapshots and packs to be all valid paths on [Windows]∩[Linux]∩[MacOs]
  - e.g. `.` or `🔥` are valid now in packs names

## Bugfixes
- Fix symlink `status` detection to check for symlink target value
- Improved sha1 calculation performance (sha1-streaming)
- Fix atomic_update_api to support WouldBlock as valid error code